### PR TITLE
hub dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+#
+# MIT License
+#
+# Copyright (c) 2023 Blamer.io
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+FROM bellsoft/liberica-openjdk-alpine:17 as build
+WORKDIR application
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+RUN java -Djarmode=layertools -jar app.jar extract
+FROM bellsoft/liberica-openjdk-alpine:17
+ENV TZ=Europe/Minsk
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+WORKDIR application
+COPY --from=build application/dependencies/ ./
+COPY --from=build application/spring-boot-loader/ ./
+COPY --from=build application/snapshot-dependencies/ ./
+RUN true
+COPY --from=build application/application/ ./
+ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]


### PR DESCRIPTION
closes #35 

@l3r8yJ take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a Dockerfile for the project.

### Detailed summary
- Added a Dockerfile with a MIT License header.
- Defined a build stage using `bellsoft/liberica-openjdk-alpine:17` as the base image.
- Set the working directory to `application`.
- Copied the JAR file into the container.
- Ran a command to extract the JAR file's layers.
- Defined a second stage using the same base image.
- Set the timezone to Europe/Minsk.
- Copied the dependencies, spring-boot-loader, and snapshot-dependencies from the build stage.
- Added a placeholder command.
- Copied the application files from the build stage.
- Set the entrypoint to run the JarLauncher from the Spring Boot loader.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->